### PR TITLE
デバッグ用関数

### DIFF
--- a/debug.gs
+++ b/debug.gs
@@ -1,0 +1,18 @@
+function debug(value) {
+  const url = PropertiesService.getScriptProperties().getProperty("SLACK_WEBHOOK_URL");
+  const options = {
+    "method": "post",
+    "payload": JSON.stringify({
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "plain_text",
+            "text": JSON.stringify(value)
+          }
+        }
+      ]
+    })
+  };
+  UrlFetchApp.fetch(url, options);
+}


### PR DESCRIPTION
POST時などのデバッグ用に使う関数を追加

引数に値を渡すと、Hookのurlにメッセージを飛ばせる
example:
```
let value = "hoge";
debug(value);
```